### PR TITLE
Add missing testing-library dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "recharts": "^2.4.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "recharts": "^2.4.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Summary
- add `@testing-library/dom` as a dev dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b26367d38832a917204ddef99b0d2