### PR TITLE
Fix supabase generics

### DIFF
--- a/src/app/backlog/page.tsx
+++ b/src/app/backlog/page.tsx
@@ -11,7 +11,7 @@ export default function BacklogPage() {
 
   useEffect(() => {
     supabase
-      .from<Bug>('bugs')
+      .from('bugs')
       .select('*')
       .is('sprint_id', null)
       .order('created_at', { ascending: false })

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -11,7 +11,7 @@ export default function BoardPage() {
 
   const loadBugs = async () => {
     const { data, error } = await supabase
-      .from<Bug>('bugs')
+      .from('bugs')
       .select('*')
       .order('created_at', { ascending: false })
     if (!error && data) setBugs(data)

--- a/src/app/bugs/[id]/page.tsx
+++ b/src/app/bugs/[id]/page.tsx
@@ -9,7 +9,7 @@ interface PageProps {
 
 export default async function BugDetailPage({ params }: PageProps) {
   const { data: bug, error } = await supabase
-    .from<Bug>('bugs')
+    .from('bugs')
     .select('*')
     .eq('id', params.id)
     .single()

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const fetchBugs = async () => {
-      const { data, error } = await supabase.from<Bug>('bugs').select('*')
+      const { data, error } = await supabase.from('bugs').select('*')
       if (error) console.error('Error loading bugs:', error)
       else setBugs(data || [])
       setLoading(false)

--- a/src/app/epics/page.tsx
+++ b/src/app/epics/page.tsx
@@ -13,7 +13,7 @@ export default function EpicsPage() {
 
   useEffect(() => {
     supabase
-      .from<Epic>('epics')
+      .from('epics')
       .select('*')
       .order('created_at', { ascending: true })
       .then(({ data, error }) => {
@@ -33,7 +33,7 @@ export default function EpicsPage() {
     setKey('')
     setDescription('')
     const { data } = await supabase
-      .from<Epic>('epics')
+      .from('epics')
       .select('*')
       .order('created_at', { ascending: true })
     setEpics(data || [])

--- a/src/app/sprints/page.tsx
+++ b/src/app/sprints/page.tsx
@@ -12,7 +12,7 @@ export default function SprintsPage() {
 
   const load = async () => {
     const { data, error } = await supabase
-      .from<Sprint>('sprints')
+      .from('sprints')
       .select('*')
       .order('start_date', { ascending: true })
     if (!error && data) setSprints(data)

--- a/src/components/bugs/AttachmentsList.tsx
+++ b/src/components/bugs/AttachmentsList.tsx
@@ -14,7 +14,7 @@ export const AttachmentsList: FC<AttachmentsListProps> = ({ bugId }) => {
 
   const load = async () => {
     const { data, error } = await supabase
-      .from<Attachment>('attachments')
+      .from('attachments')
       .select('*')
       .eq('bug_id', bugId)
       .order('uploaded_at', { ascending: false })

--- a/src/components/bugs/EpicSelector.tsx
+++ b/src/components/bugs/EpicSelector.tsx
@@ -13,7 +13,7 @@ export const EpicSelector: FC<EpicSelectorProps> = ({ value, onChange }) => {
 
   useEffect(() => {
     supabase
-      .from<Epic>('epics')
+      .from('epics')
       .select('*')
       .order('created_at', { ascending: true })
       .then(({ data, error }) => {

--- a/src/components/bugs/NewBugModal.tsx
+++ b/src/components/bugs/NewBugModal.tsx
@@ -33,7 +33,7 @@ export const NewBugModal: FC<NewBugModalProps> = ({ isOpen, onClose, onCreated }
   useEffect(() => {
     // Load users for assignee
     supabase
-      .from<{ username: string }>('users')
+      .from('users')
       .select('username')
       .then(({ data }) => {
         if (data) setUsers(data.map((u) => u.username))
@@ -41,7 +41,7 @@ export const NewBugModal: FC<NewBugModalProps> = ({ isOpen, onClose, onCreated }
 
     // Load existing bugs for parent selection
     supabase
-      .from<Pick<Bug, 'id' | 'title'>>('bugs')
+      .from('bugs')
       .select('id,title')
       .then(({ data }) => {
         if (data) setBugsList(data)
@@ -52,7 +52,7 @@ export const NewBugModal: FC<NewBugModalProps> = ({ isOpen, onClose, onCreated }
     e.preventDefault()
     setLoading(true)
     const { data, error } = await supabase
-      .from<Bug>('bugs')
+      .from('bugs')
       .insert([
         {
           title,

--- a/src/components/bugs/SaveFilter.tsx
+++ b/src/components/bugs/SaveFilter.tsx
@@ -25,7 +25,7 @@ export const SaveFilter: FC<SaveFilterProps> = ({
   useEffect(() => {
     ;(async () => {
       const { data } = await supabase
-        .from<SavedFilter>('saved_filters')
+        .from('saved_filters')
         .select('*')
         .order('created_at', { ascending: false })
       setSaved(data || [])
@@ -46,7 +46,7 @@ export const SaveFilter: FC<SaveFilterProps> = ({
     setName('')
     // reload
     const { data } = await supabase
-      .from<SavedFilter>('saved_filters')
+      .from('saved_filters')
       .select('*')
       .order('created_at', { ascending: false })
     setSaved(data || [])

--- a/src/components/bugs/SprintSelector.tsx
+++ b/src/components/bugs/SprintSelector.tsx
@@ -14,7 +14,7 @@ export const SprintSelector: FC<SprintSelectorProps> = ({ value, onChange }) => 
   useEffect(() => {
     const load = async () => {
       const { data, error } = await supabase
-        .from<Sprint>('sprints')
+        .from('sprints')
         .select('*')
         .order('start_date', { ascending: true })
       if (!error && data) setSprints(data)

--- a/src/components/bugs/SubtasksList.tsx
+++ b/src/components/bugs/SubtasksList.tsx
@@ -11,7 +11,7 @@ export const SubtasksList: FC<SubtasksListProps> = ({ parentId }) => {
   const [subs, setSubs] = useState<Bug[]>([])
   useEffect(() => {
     supabase
-      .from<Bug>('bugs')
+      .from('bugs')
       .select('*')
       .eq('parent_id', parentId)
       .order('created_at', { ascending: false })

--- a/src/components/bugs/Timeline.tsx
+++ b/src/components/bugs/Timeline.tsx
@@ -20,7 +20,7 @@ export const Timeline: FC<TimelineProps> = ({ bugId }) => {
   useEffect(() => {
     const loadActivities = async () => {
       const { data, error } = await supabase
-        .from<Activity>('activity_logs')
+        .from('activity_logs')
         .select('*')
         .eq('bug_id', bugId)
         .order('created_at', { ascending: true })

--- a/src/components/bugs/Watchers.tsx
+++ b/src/components/bugs/Watchers.tsx
@@ -13,7 +13,7 @@ export const Watchers: FC<WatchersProps> = ({ bugId }) => {
   const [watchers, setWatchers] = useState<Watcher[]>([])
 
   const loadWatchers = async () => {
-    const { data, error } = await supabase.from<Watcher>('watchers').select('*').eq('bug_id', bugId)
+    const { data, error } = await supabase.from('watchers').select('*').eq('bug_id', bugId)
     if (!error && data) setWatchers(data)
   }
 

--- a/src/hooks/useBugs.ts
+++ b/src/hooks/useBugs.ts
@@ -10,7 +10,7 @@ export function useBugs() {
     queryKey: ['bugs'],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from<Bug>('bugs')
+        .from('bugs')
         .select('*')
       if (error) throw error
       return data!

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -16,7 +16,7 @@ export function useComments(bugId: number) {
   useEffect(() => {
     const fetch = async () => {
       const { data, error } = await supabase
-        .from<Comment>('comments')
+        .from('comments')
         .select('*')
         .eq('bug_id', bugId)
         .order('created_at', { ascending: true })

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/types/database'
 
-export const supabase = createClient(
+export const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL || '',
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
 )

--- a/src/stores/bugStore.ts
+++ b/src/stores/bugStore.ts
@@ -18,7 +18,7 @@ export const useBugStore = create<BugStore>((set) => ({
   fetchBugs: async () => {
     set({ loading: true })
     const { data, error } = await supabase
-      .from<Bug>('bugs')
+      .from('bugs')
       .select('*')
       .order('created_at', { ascending: false })
     if (error) {


### PR DESCRIPTION
## Summary
- remove unused generic parameters when calling `supabase.from`
- type the Supabase client with our Database interface

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2b9a2cbc832a9918a24d679c6931