### PR TITLE
Fix duplicate PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ['@tailwindcss/postcss'],
-}
-
-export default config


### PR DESCRIPTION
## Summary
- remove unused `postcss.config.mjs`
- keep standard PostCSS setup for Tailwind

## Testing
- `npx tailwindcss -i ./src/app/globals.css -o /tmp/out.css` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b30249330832a9381f0adb88908ba